### PR TITLE
Dependencies upgrade to be compatible with BigStitcher-Spark.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,8 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>34.1.0</version>
+<!--		<version>34.1.0</version>-->
+		<version>31.1.0</version>
 		<relativePath />
 	</parent>
 
@@ -103,18 +104,32 @@
 		<dependency>
 			<groupId>sc.fiji</groupId>
 			<artifactId>bigdataviewer-core</artifactId>
+			<version>10.4.6</version>
 		</dependency>
 		<dependency>
 			<groupId>sc.fiji</groupId>
 			<artifactId>bigdataviewer-vistools</artifactId>
+			<version>1.0.0-beta-32</version>
+		</dependency>
+		<dependency>
+			<groupId>net.imglib2</groupId>
+			<artifactId>imglib2-cache</artifactId>
+			<version>1.0.0-beta-17</version>
+		</dependency>
+		<dependency>
+			<groupId>net.imglib2</groupId>
+			<artifactId>imglib2</artifactId>
+			<version>6.1.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>
 			<artifactId>n5-imglib2</artifactId>
+			<version>5.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>
 			<artifactId>n5-zarr</artifactId>
+			<version>0.0.8</version>
 		</dependency>
 
 		<!-- test dependencies -->


### PR DESCRIPTION
 * Downgraded pom.scijava to be the same as BS-S.
 * Added bigdataviewer-vistools (`wrapAsVolatile` signature).
 * Added imglib2-cache (`CachedCellImage.getAccessType` and `CachedCellImage.<init>` signatures)