### PR TITLE
Add support for ZarrKeyValueReader

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,9 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-<!--		<version>34.1.0</version>-->
-		<version>31.1.0</version>
-		<relativePath />
+		<version>36.0.0</version>
 	</parent>
 
 	<groupId>org.bigdataviewer</groupId>
@@ -89,6 +87,11 @@
 		<license.licenseName>bsd_2</license.licenseName>
 		<license.copyrightOwners>BigDataViewer developers.</license.copyrightOwners>
 
+
+		<n5.version>3.0.0-SNAPSHOT</n5.version>
+		<n5-aws-s3.version>3.2.1-SNAPSHOT</n5-aws-s3.version>
+		<n5-zarr.version>0.0.9-SNAPSHOT</n5-zarr.version>
+
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>
 	</properties>
@@ -104,33 +107,39 @@
 		<dependency>
 			<groupId>sc.fiji</groupId>
 			<artifactId>bigdataviewer-core</artifactId>
-			<version>10.4.6</version>
 		</dependency>
 		<dependency>
 			<groupId>sc.fiji</groupId>
 			<artifactId>bigdataviewer-vistools</artifactId>
-			<version>1.0.0-beta-32</version>
 		</dependency>
 		<dependency>
 			<groupId>net.imglib2</groupId>
 			<artifactId>imglib2-cache</artifactId>
-			<version>1.0.0-beta-17</version>
 		</dependency>
 		<dependency>
 			<groupId>net.imglib2</groupId>
 			<artifactId>imglib2</artifactId>
-			<version>6.1.0</version>
+		</dependency>
+
+
+		<!-- N5 -->
+		<dependency>
+			<groupId>org.janelia.saalfeldlab</groupId>
+			<artifactId>n5</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>
-			<artifactId>n5-imglib2</artifactId>
-			<version>5.0.0</version>
+			<artifactId>n5-aws-s3</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>
 			<artifactId>n5-zarr</artifactId>
-			<version>0.0.8</version>
 		</dependency>
+		<dependency>
+			<groupId>org.janelia.saalfeldlab</groupId>
+			<artifactId>n5-imglib2</artifactId>
+		</dependency>
+
 
 		<!-- test dependencies -->
 		<dependency>
@@ -138,5 +147,11 @@
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
-    </dependencies>
+		<dependency>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-s3</artifactId>
+			<version>1.12.465</version>
+		</dependency>
+
+	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -87,10 +87,9 @@
 		<license.licenseName>bsd_2</license.licenseName>
 		<license.copyrightOwners>BigDataViewer developers.</license.copyrightOwners>
 
-
-		<n5.version>3.0.0-SNAPSHOT</n5.version>
-		<n5-aws-s3.version>3.2.1-SNAPSHOT</n5-aws-s3.version>
-		<n5-zarr.version>0.0.9-SNAPSHOT</n5-zarr.version>
+		<n5.version>3.0.2</n5.version>
+		<n5-aws-s3.version>4.0.1</n5-aws-s3.version>
+		<n5-zarr.version>1.0.1</n5-zarr.version>
 
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>

--- a/src/main/java/bdv/img/omezarr/JsonTest.java
+++ b/src/main/java/bdv/img/omezarr/JsonTest.java
@@ -30,9 +30,7 @@ package bdv.img.omezarr;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import org.janelia.saalfeldlab.n5.GsonAttributesParser;
 
 import java.io.BufferedWriter;
 import java.io.IOException;

--- a/src/main/java/bdv/img/omezarr/Multiscales.java
+++ b/src/main/java/bdv/img/omezarr/Multiscales.java
@@ -31,7 +31,7 @@ package bdv.img.omezarr;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
-import org.janelia.saalfeldlab.n5.GsonAttributesParser;
+//import org.janelia.saalfeldlab.n5.GsonAttributesParser;
 import org.jcodings.util.Hash;
 
 import java.io.BufferedWriter;
@@ -227,9 +227,9 @@ public class Multiscales
         M.datasets[0] = new Dataset();
 
         m2.put(M.MULTI_SCALE_KEY, M);
-        GsonAttributesParser.insertAttributes(map, m2, gson);
-        final BufferedWriter w = new BufferedWriter(new OutputStreamWriter(System.out));
-        GsonAttributesParser.writeAttributes(w, map, gson);
+//        GsonAttributesParser.insertAttributes(map, m2, gson);
+//        final BufferedWriter w = new BufferedWriter(new OutputStreamWriter(System.out));
+//        GsonAttributesParser.writeAttributes(w, map, gson);
     }
 }
 

--- a/src/main/java/bdv/img/omezarr/S3ImgAccessTest.java
+++ b/src/main/java/bdv/img/omezarr/S3ImgAccessTest.java
@@ -1,0 +1,24 @@
+package bdv.img.omezarr;
+
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.google.gson.GsonBuilder;
+import org.janelia.saalfeldlab.n5.s3.AmazonS3KeyValueAccess;
+import org.janelia.saalfeldlab.n5.zarr.ZarrKeyValueReader;
+
+import java.io.IOException;
+
+public class S3ImgAccessTest {
+    public static void main(String[] args) throws IOException {
+        final AmazonS3 s3 = AmazonS3ClientBuilder.standard().withRegion(Regions.US_WEST_2).build();
+
+        System.out.println("");
+        final AmazonS3KeyValueAccess mys3 = new AmazonS3KeyValueAccess(s3, "aind-open-data", false);
+        final ZarrKeyValueReader zreader = new ZarrKeyValueReader(mys3,
+                "/exaSPIM_653431_2023-05-06_10-23-15/exaSPIM.zarr/tile_x_0000_y_0000_z_0000_ch_488.zarr/",
+                new GsonBuilder(), true, true, true);
+        zreader.close();
+    }
+
+}

--- a/src/main/java/bdv/img/omezarr/S3TimingTest.java
+++ b/src/main/java/bdv/img/omezarr/S3TimingTest.java
@@ -1,0 +1,69 @@
+package bdv.img.omezarr;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.AnonymousAWSCredentials;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.stream.Collectors;
+
+import org.janelia.saalfeldlab.n5.s3.AmazonS3KeyValueAccess;
+
+public class S3TimingTest {
+    public static void main(String[] args) throws IOException {
+        final String bucketName = "aind-open-data";
+        final String path = "exaSPIM_653431_2023-05-06_10-23-15/exaSPIM.zarr/tile_x_0000_y_0000_z_0000_ch_488.zarr";
+        long t0 = System.currentTimeMillis();
+
+//        final AWSStaticCredentialsProvider credentialsProvider = new AWSStaticCredentialsProvider(new AnonymousAWSCredentials());
+//        final AmazonS3 s3 = AmazonS3ClientBuilder.standard()
+//                .withCredentials(credentialsProvider)
+//                .withRegion(Regions.US_WEST_2)
+//                .build();
+
+
+        // Try with leaving the default credentials provider chain in place
+        AWSCredentials credentials = null;
+        final AWSStaticCredentialsProvider credentialsProvider;
+        try {
+            credentials = new DefaultAWSCredentialsProviderChain().getCredentials();
+        }
+        catch(final Exception e) {
+            System.out.println( "Could not load AWS credentials, falling back to anonymous." );
+        }
+        credentialsProvider = new AWSStaticCredentialsProvider(credentials == null ? new AnonymousAWSCredentials() : credentials);
+        final AmazonS3 s3 = AmazonS3ClientBuilder.standard()
+                .withCredentials(credentialsProvider)
+                .withRegion(Regions.US_WEST_2)
+                .build();
+        final AmazonS3KeyValueAccess kva = new AmazonS3KeyValueAccess(s3, bucketName, false);
+
+        long t1 = System.currentTimeMillis();
+        System.out.println("creating KeyValueAccess took: " + (t1 - t0) + " ms");
+
+        System.out.println("kva.isDirectory(path + \"/\") = " + kva.isDirectory(path + "/"));
+        long t2 = System.currentTimeMillis();
+        System.out.println("took: " + (t2 - t1) + " ms");
+
+        System.out.println("kva.isFile(path + \"/.zattrs\") = " + kva.isFile(path + "/.zattrs"));
+        long t3 = System.currentTimeMillis();
+        System.out.println("took: " + (t3 - t2) + " ms");
+
+        final InputStream inputStream = kva.lockForReading(path + "/.zattrs").newInputStream();
+        String result = new BufferedReader(new InputStreamReader(inputStream))
+                .lines().collect(Collectors.joining("\n"));
+
+        long t4 = System.currentTimeMillis();
+// System.out.println("result = " + result);
+        System.out.println("reading .zattrs took: " + (t4 - t3) + " ms");
+
+    }
+}
+


### PR DESCRIPTION
     * Add ZarrKeyValueReaderBuilder to MultiscaleImage.
     * Update ZarrImageLoader and XmlIoZarrImageLoader to use ZarrKeyValueAccessBuilder.
     * Disable caching and merging - did not work.
     * Add "s3bucket" entry to ImageLoader in the xml.
     * Pom updates.
     * Add explicit anonymous authentication to S3 connection.
     * Update n5 package versions.